### PR TITLE
Remove unknown API Product assignments from ApiM.

### DIFF
--- a/clis/ado-cli/src/commands/apim/apim-utils.ts
+++ b/clis/ado-cli/src/commands/apim/apim-utils.ts
@@ -124,7 +124,7 @@ const _publishApiToApim = async ({
     await Promise.all(
       productsToDelete.map(p =>
         client.productApi
-          .delete(resourceGroupName, apiManagementName, name, p)
+          .delete(resourceGroupName, apiManagementName, p, name)
           .catch(err => {
             logger.err(
               `Failed to delete product ${p} from api ${name} in ApiM ${apiManagementName} and resource group ${resourceGroupName} with message "${err.message}"`,


### PR DESCRIPTION
**Acceptance criteria**

- If a product assignment is removed from the api-config file then that product assignment should be removed from the API.
- Similarly, if the script encounters an unknown product assignment in an API managed by the script it will be removed.

**How to test**

_Pre-requisite:_ 
- An Api Management instance
- An API that is (or could be) managed through this script with corresponding api-config file. 
- An existing Product that should NOT belong to the API.

1. Run the script to ensure the Api and product assignment matches your api-config file.
1. Create a product assignment to associate that product with the API. Either manually in Azure Portal or by temporarilly adding the product to the api-config file.
    a) If you did it by adding the product to the api-config file - remember to remove it again.
2. Run the script
3. Verify that the product assignment has been removed from the Api in Apim.
